### PR TITLE
refactor: share OpenAPI method list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,10 @@ import { createInputSchemaFromOperation as createInputSchemaFromOperation3_0 } f
 import { createInputSchemaFromOperation as createInputSchemaFromOperation3_1 } from "./openapi/versions/3.1/createInputSchema";
 import OpenAPIClientAxios from "openapi-client-axios";
 import { AxiosError, type AxiosResponse } from "axios";
-import { getOperationIdsFromPathItem } from "./openapi/common/pathitem";
+import {
+  getOperationIdsFromPathItem,
+  OPENAPI_HTTP_METHODS,
+} from "./openapi/common/pathitem";
 
 import {
   getVersion,
@@ -98,17 +101,7 @@ async function runServer() {
       if (!operationId) continue;
       // Find the corresponding operation object
       let operation = null;
-      const httpMethods = [
-        "get",
-        "put",
-        "post",
-        "delete",
-        "options",
-        "head",
-        "patch",
-        "trace",
-      ];
-      for (const method of httpMethods) {
+      for (const method of OPENAPI_HTTP_METHODS) {
         if (pathItem[method]?.operationId === operationId) {
           operation = pathItem[method];
           break;

--- a/src/openapi/common/pathitem.ts
+++ b/src/openapi/common/pathitem.ts
@@ -5,21 +5,22 @@
  * @param pathItem - The OpenAPI PathItemObject
  * @returns Array of operationIds (string or undefined)
  */
+export const OPENAPI_HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+] as const;
+
 export function getOperationIdsFromPathItem(
   pathItem: any,
 ): Array<string | undefined> {
   const ids: Array<string | undefined> = [];
-  const httpMethods = [
-    "get",
-    "put",
-    "post",
-    "delete",
-    "options",
-    "head",
-    "patch",
-    "trace",
-  ];
-  for (const method of httpMethods) {
+  for (const method of OPENAPI_HTTP_METHODS) {
     const operation = pathItem[method];
     if (!operation) continue;
     ids.push((operation as any).operationId);

--- a/tests/openapi/common/pathitem.test.ts
+++ b/tests/openapi/common/pathitem.test.ts
@@ -3,7 +3,10 @@
  * Ensures that only HTTP method operations are considered and path-level parameters are ignored.
  */
 import { describe, it, expect } from "vitest";
-import { getOperationIdsFromPathItem } from "../../../src/openapi/common/pathitem";
+import {
+  getOperationIdsFromPathItem,
+  OPENAPI_HTTP_METHODS,
+} from "../../../src/openapi/common/pathitem";
 
 // Minimal mock of a PathItemObject with path-level parameters and valid operations
 const pathItem: any = {
@@ -34,5 +37,18 @@ describe("getOperationIdsFromPathItem", () => {
   it("returns only operationIds for HTTP methods, ignoring non-operation properties", () => {
     const ids = getOperationIdsFromPathItem(pathItem);
     expect(ids).toEqual(["getUserById", "updateUser"]);
+  });
+
+  it("returns operationIds for every OpenAPI HTTP method", () => {
+    const pathItemWithEveryMethod = Object.fromEntries(
+      OPENAPI_HTTP_METHODS.map((method) => [
+        method,
+        { operationId: `${method}Operation` },
+      ]),
+    );
+
+    expect(getOperationIdsFromPathItem(pathItemWithEveryMethod)).toEqual(
+      OPENAPI_HTTP_METHODS.map((method) => `${method}Operation`),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Export the OpenAPI HTTP method list from the path item helper.
- Reuse that list when resolving an operation by operationId.
- Add coverage for get, put, post, delete, options, head, patch, and trace.

## Validation

- `bun install --frozen-lockfile`
- `bun vitest run tests/openapi/common/pathitem.test.ts`
- `bun vitest run`
- `bun run build`
- `bunx prettier --check src/index.ts src/openapi/common/pathitem.ts tests/openapi/common/pathitem.test.ts`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Note: direct `bunx tsc --noEmit` still hits the existing project-wide rootDir configuration because examples and tests are included outside `src`.
