### PR TITLE
docs: add Xquik OpenAPI example

### DIFF
--- a/examples/xquik-claude-desktop.json
+++ b/examples/xquik-claude-desktop.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "xquik": {
+      "command": "bun",
+      "args": [
+        "/path/to/openapi-mcp-server/src/index.ts",
+        "--api",
+        "https://xquik.com/openapi.json"
+      ],
+      "env": {
+        "BASE_URL": "https://xquik.com",
+        "HEADERS": "{\"x-api-key\":\"YOUR_XQUIK_API_KEY\"}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Claude Desktop example for loading the public Xquik OpenAPI document with this MCP server.

The example uses:

- OpenAPI document: https://xquik.com/openapi.json
- Base URL: https://xquik.com
- API key header placeholder: `x-api-key`

## Validation

- `jq empty examples/xquik-claude-desktop.json`
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run build`
- `bun vitest run`

Duplicate check: no existing Xquik example or open PR found for this repo.
